### PR TITLE
Prevented grunt from opening the browser on serve

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,8 @@ module.exports = function (grunt) {
     },
     browserSync: {
       options: {
-        port: 4000
+        port: 4000,
+        open: false
       },
       server: {
         bsFiles: {


### PR DESCRIPTION
In order to host a static server, grunt needs to be prevented from opening the browser when running 'grunt serve'
