### PR TITLE
Use lighter slug module and reduce script size by a lot

### DIFF
--- a/app/js/blog.js
+++ b/app/js/blog.js
@@ -2,7 +2,7 @@ var yaml = require('js-yaml')
   , Github = require('github-api')
   , ghMerge = require('./gh-merge')
   , async = require('async')
-  , slug = require('slug')
+  , slug = require('to-slug-case')
   , $ = require('jquery')
 
 exports.init = init
@@ -121,10 +121,10 @@ function createPost (title, author, categories, text) {
 function createTitle (title) {
   if (!title) throw new Error()
   return new Date().toJSON().replace(/T.*$/, '') + '-' +
-    slug(title.toLowerCase()) + '.md'
+    slug(title) + '.md'
 }
 
 function createBranchName (title) {
   if (!title) throw new Error()
-  return 'post-' + slug(title.toLowerCase())
+  return 'post-' + slug(title)
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,7 +70,7 @@ gulp.task('css', function () {
     .pipe($.if(!production, $.sourcemaps.write()))
     .pipe(gulp.dest('.tmp/css'))
     .pipe($.if(!production, reload({ stream: true })))
-    .pipe($.if(!production, $.size({ title: 'styles' })))
+    .pipe($.size({ title: 'styles preminification' }))
 })
 
 // javascripts with browserify
@@ -88,7 +88,7 @@ gulp.task('js', function () {
       .pipe($.if(!production, $.sourcemaps.write()))
       .pipe(gulp.dest('.tmp/js'))
       .pipe($.if(!production, reload({ stream: true })))
-      .pipe($.if(!production, $.size({ title: 'javascripts' })))
+      .pipe($.size({ title: 'javascripts preminification' }))
   }
   return bundle()
 })
@@ -117,9 +117,11 @@ gulp.task('html', function () {
     .pipe(assets)
     .pipe(jsFilter)
     .pipe($.uglify())
+    .pipe($.size({ title: 'scripts postminification' }))
     .pipe(jsFilter.restore())
     .pipe(cssFilter)
     .pipe($.minifyCss())
+    .pipe($.size({ title: 'styles postminification' }))
     .pipe(cssFilter.restore())
     .pipe($.rev())
     .pipe(assets.restore())
@@ -127,10 +129,11 @@ gulp.task('html', function () {
     .pipe($.useref())
     .pipe($.revReplace())
     .pipe(htmlFilter)
+    .pipe($.size({ title: 'html preminification' }))
     .pipe($.minifyHtml())
+    .pipe($.size({ title: 'html postminification' }))
     .pipe(htmlFilter.restore())
     .pipe(gulp.dest('dist'))
-    .pipe($.size({ title: 'html' }))
 
 })
 
@@ -141,11 +144,13 @@ gulp.task('img', function () {
 
   return gulp.src('dist/**/*')
     .pipe(imgFilter)
+    .pipe($.size({ title: 'images preminification' }))
     .pipe($.imagemin({
       progressive: true,
       svgoplugins: [{ removeViewBox: false }],
       use: [require('imagemin-pngquant')()]
     }))
+    .pipe($.size({ title: 'images postminification' }))
     .pipe($.rev())
     .pipe(imgFilter.restore())
     .pipe($.revReplace())

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mousetrap": "^1.4.6",
     "ramda": "^0.8.0",
     "run-sequence": "^1.0.2",
-    "slug": "^0.8.0",
+    "to-slug-case": "^0.1.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^2.2.1"


### PR DESCRIPTION
Before (look for `scripts postminification`) (about 1.76 MB)

![~1.76 MB ungunzipped](http://a.pomf.se/fnidwm.png)

After (about 250 KB)

![~250 KB ungunzipped](http://a.pomf.se/skwkww.png)

These are also ungzipped values, so compression could cut down on filesize even more.

## Notes

- Basically this removes a giant unicode file (~1.6 MB) that was embedded in the script bundle
- `slug` was removed, `to-slug-case` was installed
- The build script that updates the website must have `npm install` in it for this to work