### PR TITLE
use environmental vars to control secrets

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# copy this to .env and change the keys
+GH_TOKEN=insert_gh_oauth_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ app/_bower_components
 dist
 node_modules
 .tmp
+.env

--- a/app/js/blog.js
+++ b/app/js/blog.js
@@ -8,7 +8,7 @@ var yaml = require('js-yaml')
 
 exports.init = init
 
-var GH_TOKEN = 'a2af087c98412c3a61b097613b10ca889a887c99' // plz dont steal
+var GH_TOKEN = process.env.GH_TOKEN
   , GH_USER = 'mvrt-115'
   , GH_REPO = 'MVRT_Site'
   , GH_BRANCH = 'master'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+require('dotenv').load()
+
 var gulp = require('gulp')
   , $ = require('gulp-load-plugins')({
       rename: {
@@ -78,6 +80,8 @@ gulp.task('js', function () {
   var bOptions = { entries: [paths.js], debug: true }
   var b = production ? browserify(bOptions) :
     watchify(browserify(bOptions), watchify.args)
+  b.transform('envify')
+  b.transform('browserify-shim')
   if (!production) b.on('update', bundle)
   function bundle () {
     return b.bundle()

--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
     "preinstall": "bundle install && bower install",
     "postinstall": "./node_modules/.bin/gulp"
   },
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
-  },
   "browser": {
     "waypoints": "./app/_bower_components/waypoints/lib/jquery.waypoints.js",
     "sticky": "./app/_bower_components/waypoints/lib/shortcuts/sticky.js"
@@ -40,6 +35,8 @@
     "browserify-shim": "^3.8.2",
     "dateformat": "^1.0.11",
     "del": "^1.1.1",
+    "dotenv": "^0.5.1",
+    "envify": "^3.2.0",
     "github-api": "^0.10.3",
     "gulp": "^3.8.10",
     "gulp-autoprefixer": "^2.0.0",


### PR DESCRIPTION
You know, to protect the GH_TOKEN.

Of course, we could add other variables to `.env`, but I don't really care.

(Probably will fix) #89.

_This requires that the build script has an `npm install`._